### PR TITLE
fix: use echo -e to escape newline

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -3,7 +3,7 @@
 # usage: addenv env_name path
 function addenv() {
   sed -i -e "/^export $1=.*/d" ~/.bashrc
-  echo "\nexport $1=`readlink -e $2`" >> ~/.bashrc
+  echo -e "\nexport $1=`readlink -e $2`" >> ~/.bashrc
   echo "By default this script will add environment variables into ~/.bashrc."
   echo "After that, please run 'source ~/.bashrc' to let these variables take effect."
   echo "If you use shell other than bash, please add these environment variables manually."


### PR DESCRIPTION
Thanks for this great project! I was getting `\nexport` instead of `export` appended into `.bashrc` when running `bash init.sh nemu` as the following image.

<img width="761" alt="image" src="https://github.com/user-attachments/assets/bba5b0b9-3192-4511-a20b-1772d05c3acc">

It seems `echo -e` fixes the problem.

Best,
Haotian